### PR TITLE
fixed error message relating to PW requirements change

### DIFF
--- a/src/app/components/elements/modals/RequiredAccountInformationModal.tsx
+++ b/src/app/components/elements/modals/RequiredAccountInformationModal.tsx
@@ -29,6 +29,7 @@ const RequiredAccountInfoBody = () => {
     const dispatch = useAppDispatch();
     const user = useAppSelector(selectors.user.orNull);
     const userPreferences = useAppSelector((state: AppState) => state?.userPreferences);
+    const errorMessage = useAppSelector((state: AppState) => state?.error || null);
 
     // Local state
     const [submissionAttempted, setSubmissionAttempted] = useState(false);

--- a/src/app/components/elements/panels/UserEmailPreferences.tsx
+++ b/src/app/components/elements/panels/UserEmailPreferences.tsx
@@ -26,20 +26,15 @@ interface UserEmailPreferencesProps {
 export const UserEmailPreference = ({emailPreferences, setEmailPreferences, submissionAttempted, idPrefix="my-account-"}: UserEmailPreferencesProps) => {
     const user = useAppSelector(selectors.user.orNull);
     const userIsStudent = isStudent({...user, loggedIn: true});
-    const error = useAppSelector((state: AppState) => state && state.error);
     const isaacEmailPreferenceDescriptions = {
         assignments: "Receive assignment notifications from your teacher.",
         news: "Be the first to know about new topics, new platform features, and our fantastic competition giveaways.",
         events: "Get valuable updates on our free student workshops/teacher CPD events happening near you."
     };
 
-    // temporarily specified not to display PW error - this can currently happen if user has attempted registration with an invalid PW, then corrected it.
-    // TO DO: PW restrictions on front end will prevent this error from occurring, so this can be removed.
+    // temporarily only showing error relating to not filling out all preferences.
+    // TO DO: PW restrictions on front end will prevent unwanted from occurring, and this can then be changed
     let errorMessage = null;
-    if (error && error.type === "generalError" && !error.generalError.includes("Password must be at least 12 characters") ) {
-        errorMessage = error.generalError;
-    } 
-    // made this a separate if statement so that any general error text would be overridden by the more specific error message above
     if (submissionAttempted && !validateEmailPreferences(emailPreferences)) {
         errorMessage = "Please specify all preferences"
     }

--- a/src/app/components/elements/panels/UserEmailPreferences.tsx
+++ b/src/app/components/elements/panels/UserEmailPreferences.tsx
@@ -33,10 +33,14 @@ export const UserEmailPreference = ({emailPreferences, setEmailPreferences, subm
         events: "Get valuable updates on our free student workshops/teacher CPD events happening near you."
     };
 
+    // temporarily specified not to display PW error - this can currently happen if user has attempted registration with an invalid PW, then corrected it.
+    // TO DO: PW restrictions on front end will prevent this error from occurring, so this can be removed.
     let errorMessage = null;
-    if (error && error.type === "generalError") {
+    if (error && error.type === "generalError" && !error.generalError.includes("Password must be at least 12 characters") ) {
         errorMessage = error.generalError;
-    } else  if (submissionAttempted && !validateEmailPreferences(emailPreferences)) {
+    } 
+    // made this a separate if statement so that any general error text would be overridden by the more specific error message above
+    if (submissionAttempted && !validateEmailPreferences(emailPreferences)) {
         errorMessage = "Please specify all preferences"
     }
 

--- a/src/app/components/pages/MyAccount.tsx
+++ b/src/app/components/pages/MyAccount.tsx
@@ -371,7 +371,7 @@ const AccountPageComponent = ({user, getChosenUserAuthSettings, errorMessage, us
                         <CardFooter className="py-4">
                             <Row>
                                 <Col size={12} md={{size: 6, offset: 3}}>
-                                    {errorMessage?.type === "generalError" && !errorMessage?.generalError.includes("Password must be at least 12 characters") && <h3 role="alert" className="text-danger text-center">
+                                    {errorMessage?.type === "generalError" && errorMessage?.generalError.includes("Not all required fields") && <h3 role="alert" className="text-danger text-center">
                                         {errorMessage.generalError}
                                     </h3>}
                                     {/* Teacher connections does not have a save */}

--- a/src/app/components/pages/MyAccount.tsx
+++ b/src/app/components/pages/MyAccount.tsx
@@ -371,7 +371,7 @@ const AccountPageComponent = ({user, getChosenUserAuthSettings, errorMessage, us
                         <CardFooter className="py-4">
                             <Row>
                                 <Col size={12} md={{size: 6, offset: 3}}>
-                                    {errorMessage?.type === "generalError" && <h3 role="alert" className="text-danger text-center">
+                                    {errorMessage?.type === "generalError" && !errorMessage?.generalError.includes("Password must be at least 12 characters") && <h3 role="alert" className="text-danger text-center">
                                         {errorMessage.generalError}
                                     </h3>}
                                     {/* Teacher connections does not have a save */}


### PR DESCRIPTION
This is a temporary fix to prevent incorrect error message showing up if user initially tries to register with incorrect PW requirements, then successfully registers and PW error (as a "generalError") is still displayed on the email preferences and my account page.  This should not happen in the future as front end changes are planned to reflect changed PW requirements and prevent users from submitting registration form until they are met. 