### PR TITLE
preventing duplicate logoutUser dispatch

### DIFF
--- a/src/app/components/handlers/LogOutHandler.tsx
+++ b/src/app/components/handlers/LogOutHandler.tsx
@@ -4,7 +4,7 @@ import {IsaacSpinner} from "./IsaacSpinner";
 
 export const LogOutHandler = () => {
     const dispatch = useAppDispatch();
-    useEffect(() => {dispatch(logOutUser())});
+    useEffect(() => {dispatch(logOutUser())}, [dispatch]);
     return <React.Fragment>
         <div className="w-100 text-center">
             <h2 className="pt-5 pb-2">


### PR DESCRIPTION
Fixed rendering issue which caused the logout dispatch to be called twice; does not currently trigger an error message, but would after some upcoming backend changes