### PR TITLE
adjusted dates on registeredContextsLastConfirmed...

### DIFF
--- a/src/mocks/data.ts
+++ b/src/mocks/data.ts
@@ -17,7 +17,7 @@ export const mockUser = {
             examBoard: "all"
         }
     ],
-    registeredContextsLastConfirmed: DAYS_AGO(3),
+    registeredContextsLastConfirmed: DAYS_AGO(0),
     firstLogin: false,
     lastUpdated: DAYS_AGO(1),
     lastSeen: DAYS_AGO(1),
@@ -40,7 +40,7 @@ export const buildMockStudent = <T extends number>(id: T extends (typeof mockUse
             stage: "all",
             examBoard: "all"
         }],
-        registeredContextsLastConfirmed: DAYS_AGO(3),
+        registeredContextsLastConfirmed: DAYS_AGO(0),
         firstLogin: false,
         lastUpdated: DAYS_AGO(1),
         lastSeen: DAYS_AGO(1),
@@ -64,7 +64,7 @@ export const buildMockTeacher = <T extends number>(id: T extends (typeof mockUse
             stage: "all",
             examBoard: "all"
         }],
-        registeredContextsLastConfirmed: DAYS_AGO(3),
+        registeredContextsLastConfirmed: DAYS_AGO(0),
         firstLogin: false,
         lastUpdated: DAYS_AGO(1),
         lastSeen: DAYS_AGO(1),


### PR DESCRIPTION
 ...to prevent unexpected test failures on first 3 days of August

Most tests are assuming that registeredContextsLastConfirmed would be since the most recent August, avoiding triggering the reconfirmation modal (which is tested for separately in UserContextReconfirmationModal.test.tsx)