### PR TITLE
Student/Teacher headcount in SelectedEventDetails

### DIFF
--- a/src/app/components/elements/panels/SelectedEventDetails.tsx
+++ b/src/app/components/elements/panels/SelectedEventDetails.tsx
@@ -12,13 +12,18 @@ export const countStudentsAndTeachers = (eventBookings: EventBookingDTO[]) => {
 
   eventBookings.forEach((booking) => {
     const role = booking.userBooked?.role;
-    if (role === "STUDENT") {
-      studentCount++;
-    } else if (role === "TEACHER") {
-      teacherCount++;
+    const bookingStatus = booking.bookingStatus;
+
+    if (role && bookingStatus) {
+      const validStatus = ["CONFIRMED", "ATTENDED", "ABSENT"].includes(bookingStatus);
+
+      if (role === "STUDENT" && validStatus) {
+        studentCount++;
+      } else if (role === "TEACHER" && validStatus) {
+        teacherCount++;
+      }
     }
   });
-
   return {
     studentCount,
     teacherCount,

--- a/src/mocks/data.ts
+++ b/src/mocks/data.ts
@@ -153,6 +153,37 @@ export const mockEventBookings: EventBookingDTO[] = [
   },
 ];
 
+export const mockCancelledEventBooking = {
+  bookingId: 1005,
+  userBooked: {
+    givenName: "Cancelled",
+    familyName: "Teacher",
+    role: "TEACHER",
+    authorisedFullAccess: false,
+    emailVerificationStatus: "VERIFIED",
+    teacherPending: false,
+    registeredContexts: [
+      {
+        stage: "all",
+        examBoard: "ocr",
+      },
+    ],
+    email: "cancelled_teacher@test.com",
+    id: 202,
+  },
+  reservedById: 0,
+  eventId: "example_event",
+  eventTitle: "Example Event",
+  eventDate: 1698850800000 as unknown as Date,
+  bookingStatus: "CANCELLED",
+  bookingDate: 1695897589235 as unknown as Date,
+  additionalInformation: {
+    experienceLevel: "teacher",
+    jobTitle: "CS Teacher",
+  },
+  updated: 1695897589235 as unknown as Date,
+};
+
 export const mockEvent = {
   id: "example_event",
   title: "Example Event",

--- a/src/test/components/elements/panels/SelectedEventDetails/countStudentsAndTeachers.test.tsx
+++ b/src/test/components/elements/panels/SelectedEventDetails/countStudentsAndTeachers.test.tsx
@@ -1,5 +1,6 @@
+import { EventBookingDTO } from "../../../../../IsaacApiTypes";
 import { countStudentsAndTeachers } from "../../../../../app/components/elements/panels/SelectedEventDetails";
-import { mockEventBookings } from "../../../../../mocks/data";
+import { mockCancelledEventBooking, mockEventBookings } from "../../../../../mocks/data";
 
 describe("countStudentsAndTeachers", () => {
   it("returns an object with studentCount and teacherCount both set to 0 when passed an empty array", () => {
@@ -37,6 +38,11 @@ describe("countStudentsAndTeachers", () => {
         bookingStatus: "CONFIRMED",
       },
     ]);
+    expect(results).toEqual({ studentCount: 3, teacherCount: 2 });
+  });
+
+  it("should not count bookings with invalid bookingStatus", () => {
+    const results = countStudentsAndTeachers([...mockEventBookings, mockCancelledEventBooking] as EventBookingDTO[]);
     expect(results).toEqual({ studentCount: 3, teacherCount: 2 });
   });
 });


### PR DESCRIPTION
https://github.com/isaaccomputerscience/isaac-cs-issues/issues/186

Student/Teacher headcounts now only include bookings that are CONFIRMED, ATTENDED or ABSENT. 