### PR TITLE
removed CIE from topics page

### DIFF
--- a/src/app/components/pages/AllTopics.tsx
+++ b/src/app/components/pages/AllTopics.tsx
@@ -56,8 +56,13 @@ export const AllTopics = ({ stage }: { stage: STAGE.A_LEVEL | STAGE.GCSE }) => {
   const history = useHistory();
   const location = useLocation();
 
+  // hiding CIE from A Level topics page
+  const EXAM_BOARDS_CS_A_LEVEL_MODIFIED = new Set(
+    [...EXAM_BOARDS_CS_A_LEVEL].filter((board) => board !== EXAM_BOARD.CIE),
+  );
+
   const stageExamBoards = Array.from(
-    { [STAGE.GCSE]: EXAM_BOARDS_CS_GCSE, [STAGE.A_LEVEL]: EXAM_BOARDS_CS_A_LEVEL }[stage],
+    { [STAGE.GCSE]: EXAM_BOARDS_CS_GCSE, [STAGE.A_LEVEL]: EXAM_BOARDS_CS_A_LEVEL_MODIFIED }[stage],
   );
 
   useEffect(
@@ -150,7 +155,7 @@ export const AllTopics = ({ stage }: { stage: STAGE.A_LEVEL | STAGE.GCSE }) => {
 
   const metaDescriptionMap = {
     [STAGE.A_LEVEL]:
-      "Our free A level Computer Science topics cover the AQA, CIE, OCR, Eduqas, and WJEC exam specifications. Use our exam questions to learn or revise today.",
+      "Our free A level Computer Science topics cover the AQA, OCR, Eduqas, and WJEC exam specifications. Use our exam questions to learn or revise today.",
     [STAGE.GCSE]:
       "Discover our free GCSE Computer Science topics and questions. We cover AQA, Edexcel, Eduqas, OCR, and WJEC. Learn and revise for your exams with us today.",
   };


### PR DESCRIPTION
https://github.com/isaaccomputerscience/isaac-cs-issues/issues/316

Small change to remove CIE from the topics page; to be left in place on the wider site, just removing the topic summary page