### PR TITLE
ImmutableStateInvariantMiddleware affecting tests in dev environment (#23)

### DIFF
--- a/src/app/state/store.tsx
+++ b/src/app/state/store.tsx
@@ -23,20 +23,20 @@ const defaultMiddlewareOptions = {
 
 export const store = configureStore({
   reducer: rootReducer,
-  // [thunk, immutableStateInvariant, serializableStateInvariant] are all in the default middleware and included by default
-  // in development, with only thunk included in production.
-  // See https://redux-toolkit.js.org/api/getDefaultMiddleware#customizing-the-included-middleware
   middleware: (getDefaultMiddleware) => {
-    const newMiddleware = getDefaultMiddleware(defaultMiddlewareOptions).concat(middleware);
+    const newMiddleware = getDefaultMiddleware({
+      immutableCheck: false, // Disable immutable state invariant middleware
+      serializableCheck: false, // Disable serializability check middleware
+    }).concat(middleware);
+
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
     // @ts-ignore
     if (process.env.NODE_ENV !== "production" && !window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__) {
       newMiddleware.concat([reduxLogger]);
     }
+
     return newMiddleware;
   },
-  preloadedState: {},
-  devTools: process.env.NODE_ENV !== "production",
 });
 
 export type AppDispatch = typeof store.dispatch;

--- a/src/app/state/store.tsx
+++ b/src/app/state/store.tsx
@@ -33,6 +33,8 @@ export const store = configureStore({
 
     return newMiddleware;
   },
+  preloadedState: {},
+  devTools: process.env.NODE_ENV !== "production",
 });
 
 export type AppDispatch = typeof store.dispatch;

--- a/src/app/state/store.tsx
+++ b/src/app/state/store.tsx
@@ -17,16 +17,12 @@ export const middleware: Middleware[] = [
   userConsistencyCheckerMiddleware,
   notificationCheckerMiddleware,
 ];
-const defaultMiddlewareOptions = {
-  serializableCheck: process.env.NODE_ENV !== "test",
-};
-
 export const store = configureStore({
   reducer: rootReducer,
   middleware: (getDefaultMiddleware) => {
     const newMiddleware = getDefaultMiddleware({
-      immutableCheck: false, // Disable immutable state invariant middleware
-      serializableCheck: false, // Disable serializability check middleware
+      immutableCheck: false,
+      serializableCheck: false,
     }).concat(middleware);
 
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment

--- a/src/app/state/store.tsx
+++ b/src/app/state/store.tsx
@@ -22,7 +22,7 @@ export const store = configureStore({
   middleware: (getDefaultMiddleware) => {
     const newMiddleware = getDefaultMiddleware({
       immutableCheck: false,
-      serializableCheck: false,
+      serializableCheck: process.env.NODE_ENV !== "test",
     }).concat(middleware);
 
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment


### PR DESCRIPTION
Ticket: https://github.com/isaaccomputerscience/isaac-cs-issues/issues/23

Sometimes when running tests in React app a console warning will appear:

_"ImmutableStateInvariantMiddleware took 106ms, which is more than the warning threshold of 32ms.
If your state or actions are very large, you may want to disable the middleware as it might cause too much of a slowdown in development mode."_