### PR TITLE
557/shav-c-reliability-fix

### DIFF
--- a/src/app/components/elements/panels/ManageExistingBookings.tsx
+++ b/src/app/components/elements/panels/ManageExistingBookings.tsx
@@ -200,8 +200,8 @@ const EmailOrExport = ({
 
   function relevantUsers(bookingType: string) {
     const idsToReturn: number[] = [];
-    augmentedEventBookings.map((booking: DetailedEventBookingDTO & { schoolName?: string }) => {
-      if (booking.userBooked?.id && booking.bookingStatus == bookingType) {
+    augmentedEventBookings.forEach((booking: DetailedEventBookingDTO & { schoolName?: string }) => {
+      if (booking.userBooked?.id && booking.bookingStatus === bookingType) {
         idsToReturn.push(booking.userBooked.id);
       }
     });


### PR DESCRIPTION
Description:
This PR addresses issue [#557](https://github.com/isaaccomputerscience/isaac-cs-issues/issues/557) by replacing the use of `map` with `forEach` in the `relevantUsers` function to resolve a SonarCloud reliability concern. The change improves code efficiency since the return value of `map` was not being used. Additionally, the comparison operator has been updated from `==` to `===` for stricter type checking, enhancing code reliability. Importantly, this refactor does not alter the function's behaviour; it maintains the same output while improving efficiency and readability. All existing unit tests have been run and pass successfully, and manual testing confirms that the function continues to work as expected.

Ticket: https://github.com/isaaccomputerscience/isaac-cs-issues/issues/557

Media attachement(s):
Screenshot of Unit tests passing under the `ManageExistingBooking.test.tsx` file

![Screenshot 2024-11-29 at 12 55 16](https://github.com/user-attachments/assets/5a29c263-d207-4e27-9372-97eea71aa98e)