### PR TITLE
568/shav-fix: correct typo and clarify eligibility on National Competition page

### DIFF
--- a/src/app/components/pages/IsaacCompetition/content.ts
+++ b/src/app/components/pages/IsaacCompetition/content.ts
@@ -62,7 +62,7 @@ export default {
       description:
         "This competition encourages teamwork, allowing groups of up to 4 students or individual entries with teacher support.",
       requirements:
-        "Eligible participants must be in Year 9, 10, or 11 during the 2024/2025 academic year and attend a state-funded school; private, independent, and home-educated students are not eligible.",
+        "Eligible participants must be in Year 9, 10, or 11 during the 2024/2025 academic year and attend a state-funded school in England; private, independent, and home-educated students are not eligible.",
     },
     prizes: {
       title: "🏆 The prizes",
@@ -81,7 +81,7 @@ export default {
       entries: [
         { event: "Entries open", date: "January" },
         { event: "Entries close", date: "17 March" },
-        { event: "Finalist selected", date: "May" },
+        { event: "Finalists selected", date: "May" },
         { event: "The finals", date: "2 to 13 June" },
       ],
     },


### PR DESCRIPTION
## Changes to `content.ts` for National Competition page

This PR addresses two small copy tweaks requested by the Comms team:

1. Corrects a typo in the 3rd timeline box:
   - 'finalist' → 'finalists'

2. Clarifies eligibility criteria in the 'Who can join?' section:
   - Updated to specify 'state funded school **in England**'

These changes aim to improve accuracy and provide clearer information to users about the National Competition eligibility.

Please review the changes in the `content.ts` file.


Ticket: https://github.com/isaaccomputerscience/isaac-cs-issues/issues/568
Media attachement(s):
Screenshot of the changes updated onto the National Competition landing page

![Screenshot 2024-12-18 at 15 29 28](https://github.com/user-attachments/assets/74cefb86-f8f1-41ab-87de-057fecbb5990)
