### PR TITLE
478/shav-glossary-page-enchancement

### DIFF
--- a/src/app/components/content/IsaacGlossaryTerm.tsx
+++ b/src/app/components/content/IsaacGlossaryTerm.tsx
@@ -2,7 +2,6 @@ import React, { Ref } from "react";
 import { Col, Row } from "reactstrap";
 import { GlossaryTermDTO } from "../../../IsaacApiTypes";
 import { IsaacContent } from "./IsaacContent";
-import { formatGlossaryTermId } from "../pages/Glossary";
 
 interface IsaacGlossaryTermProps {
   doc: GlossaryTermDTO;
@@ -10,7 +9,7 @@ interface IsaacGlossaryTermProps {
   linkToGlossary?: boolean;
 }
 
-const IsaacGlossaryTermComponent = ({ doc, inPortal, linkToGlossary }: IsaacGlossaryTermProps, ref: Ref<any>) => {
+const IsaacGlossaryTermComponent = ({ doc, inPortal }: IsaacGlossaryTermProps, ref: Ref<any>) => {
   const termContents = (
     <>
       <Col md={3} className="glossary_term_name">

--- a/src/app/components/content/IsaacGlossaryTerm.tsx
+++ b/src/app/components/content/IsaacGlossaryTerm.tsx
@@ -6,6 +6,7 @@ import { IsaacContent } from "./IsaacContent";
 interface IsaacGlossaryTermProps {
   doc: GlossaryTermDTO;
   inPortal?: boolean;
+  linkToGlossary?: boolean;
 }
 
 const IsaacGlossaryTermComponent = ({ doc, inPortal }: IsaacGlossaryTermProps, ref: Ref<any>) => {

--- a/src/app/components/content/IsaacGlossaryTerm.tsx
+++ b/src/app/components/content/IsaacGlossaryTerm.tsx
@@ -15,13 +15,7 @@ const IsaacGlossaryTermComponent = ({ doc, inPortal, linkToGlossary }: IsaacGlos
     <>
       <Col md={3} className="glossary_term_name">
         <p ref={ref}>
-          {linkToGlossary && (
-            <a href={`#${(doc.id && formatGlossaryTermId(doc.id)) ?? ""}`}>
-              <img src="/assets/link-variant.png" className="pr-2" alt="direct link" />
-              <strong>{doc.value}</strong>
-            </a>
-          )}
-          {!linkToGlossary && <strong>{doc.value}</strong>}
+          <strong>{doc.value}</strong>
           <span className="only-print">: </span>
         </p>
       </Col>

--- a/src/app/components/content/IsaacGlossaryTerm.tsx
+++ b/src/app/components/content/IsaacGlossaryTerm.tsx
@@ -6,7 +6,6 @@ import { IsaacContent } from "./IsaacContent";
 interface IsaacGlossaryTermProps {
   doc: GlossaryTermDTO;
   inPortal?: boolean;
-  linkToGlossary?: boolean;
 }
 
 const IsaacGlossaryTermComponent = ({ doc, inPortal }: IsaacGlossaryTermProps, ref: Ref<any>) => {

--- a/src/app/components/pages/Glossary.tsx
+++ b/src/app/components/pages/Glossary.tsx
@@ -291,7 +291,6 @@ export const Glossary = () => {
                         glossaryTermRefs.current.set((term.id && formatGlossaryTermId(term.id)) ?? "", el);
                       }}
                       doc={term}
-                      linkToGlossary={true}
                     />
                   ))}
                 </Col>

--- a/src/app/components/site/Routes.tsx
+++ b/src/app/components/site/Routes.tsx
@@ -72,14 +72,7 @@ export const Routes = [
   />,
 
   // Glossary:
-  <TrackedRoute
-    key={key++}
-    exact
-    path="/glossary"
-    ifUser={isLoggedIn}
-    component={Glossary}
-    userAgent={window.navigator.userAgent}
-  />,
+  <TrackedRoute key={key++} exact path="/glossary" component={Glossary} userAgent={window.navigator.userAgent} />,
 
   // Static pages:
   <StaticPageRoute key={key++} exact path="/about" pageId="about_us" />,


### PR DESCRIPTION
Description:
This pull request simplifies the `IsaacGlossaryTerm` component by removing the `linkToGlossary` functionality and refactoring the rendering logic, while simultaneously removing the login requirement for accessing the glossary page. The changes aim to improve user accessibility and streamline the component's structure, making the glossary more straightforward and immediately available to all users without authentication barriers.

Ticket: https://github.com/isaaccomputerscience/isaac-cs-issues/issues/478

Media Attachement(s):

https://github.com/user-attachments/assets/3d56fd57-8fcf-41c3-8986-eb56982aa004
