### PR TITLE
558/shav-event-card-update

### DIFF
--- a/src/app/components/elements/cards/EventCard.tsx
+++ b/src/app/components/elements/cards/EventCard.tsx
@@ -98,7 +98,6 @@ export const EventCard = ({ event, pod = false }: { event: AugmentedEvent; pod?:
             <span className="d-block my-2" data-testid="event-card-location">
               <span className="card-sub-title">Where</span>
               <span className="d-block">
-                <span className="font-weight-bold">Location:</span>{" "}
                 {event.isVirtual ? (
                   <span>Online</span>
                 ) : (


### PR DESCRIPTION
Description:
In this PR, we refine the event card's location display by removing the redundant  **"Location:"** label. The change focuses on improving UI clarity while maintaining the existing logic for rendering both virtual and physical event locations. By eliminating the unnecessary text, we create a cleaner, more concise user experience without compromising the information's readability. The "Where" subtitle remains intact, providing sufficient context for the location details.

Ticket: https://github.com/isaaccomputerscience/isaac-cs-issues/issues/558

Media Attachment(s):

<img width="1386" alt="Screenshot 2025-01-16 at 09 59 31" src="https://github.com/user-attachments/assets/bf5fec80-0fee-4d1d-b2c8-4801bdc81efa" />

The image of the localhost environment demonstrates the effect of our recent change in how event locations are displayed. The "Exploring Tech Apprenticeships with the BBC" events now show the location information directly without the "Location:" prefix, reflecting our UI optimisation. For instance, you might see:

Where
Online

Or for physical events:

Where
BBC, London **(example)**

In contrast, the test events don't exhibit this change because they don't have a location specified. This absence of location information means these events aren't affected by our removal of the "Location:" label, as there was no location to display in the first place. The difference between these two types of events in the localhost environment clearly illustrates the impact and scope of our recent UI refinement.