### PR TITLE
588/shav-small-copy-competition-changes

### DIFF
--- a/src/app/components/pages/IsaacCompetition/HomepageHighlight/HomepageHighlight.tsx
+++ b/src/app/components/pages/IsaacCompetition/HomepageHighlight/HomepageHighlight.tsx
@@ -7,7 +7,7 @@ const HomepageHighlight = () => {
     <Container className="pt-2 pb-5">
       <Row className="homepage-highlight rounded justify-content-center">
         <Col xs={12} className="text-center">
-          <h1 className="homepage-highlight-sub-title py-4">2025 Isaac Computer Science competition</h1>
+          <h1 className="homepage-highlight-sub-title py-4">2025 National Computer Science competition</h1>
           <h1 className="homepage-highlight-title pb-4">Entries are now open</h1>
         </Col>
         <Col xs={12} className="pb-4 text-center d-flex justify-content-center">

--- a/src/app/components/pages/IsaacCompetition/content.ts
+++ b/src/app/components/pages/IsaacCompetition/content.ts
@@ -45,7 +45,7 @@ export default {
         "2. Students and teachers create or log in to an account",
         "3. Attend our Q&A sessions for tips and tricks on entries (coming soon)",
         "4. Boost your knowledge with our Student Boosters and Gameboards",
-        "5. Submit your entry! The finalists will be selected and invited to a final in Manchester, Birmingham, or London (depending on the location of your school) in June",
+        "5. Submit your entry! The finalists will be selected and invited to a final in Birmingham on 19 May.",
       ],
     },
     whyJoin: {


### PR DESCRIPTION
Description:

This PR addresses a request from the STEM Programmes team to update copy related to the Competition. Specifically, it changes _"Isaac Computer Science competition"_ to **"National Computer Science competition"** in the homepage highlight section. Furthermore, it updates point 5 in the **"How does it work?"** section on the competition page to read: **"Submit your entry! The finalists will be selected and invited to a final in Birmingham on 19 May."** These changes are intended to provide clearer and more accurate information to prospective participants.

Ticket: https://github.com/isaaccomputerscience/isaac-cs-issues/issues/588

Media attachement(s):

_Screenshot of the changes in the Competition Highlight on the Homepage_
![Screenshot 2025-02-11 at 09 55 05](https://github.com/user-attachments/assets/9f2587f2-be72-47f6-ba8f-efb93096ed55)


_Screenshot of the changes in the **'How does it works?'** section_
![Screenshot 2025-02-11 at 09 54 52](https://github.com/user-attachments/assets/2f4f2666-9eda-4f94-9228-afd532441737)
