### PR TITLE
Entry form copy addition #608

### DIFF
--- a/src/app/components/pages/IsaacCompetition/EntryForm/CompetitionEntryForm.tsx
+++ b/src/app/components/pages/IsaacCompetition/EntryForm/CompetitionEntryForm.tsx
@@ -99,6 +99,7 @@ const CompetitionEntryForm = ({ handleTermsClick }: CompetitionEntryFormProps) =
                 />
                 <FormInput
                   label="Group"
+                  subLabel="Please ensure each group has no more than 4 students."
                   type="select"
                   id="formGroup"
                   required

--- a/src/app/components/pages/IsaacCompetition/EntryForm/FormInput.tsx
+++ b/src/app/components/pages/IsaacCompetition/EntryForm/FormInput.tsx
@@ -4,6 +4,7 @@ import { InputType } from "reactstrap/es/Input";
 
 interface FormInputProps {
   label: string;
+  subLabel?: string;
   type: string;
   id: string;
   disabled: boolean;
@@ -18,6 +19,7 @@ interface FormInputProps {
 
 const FormInput = ({
   label,
+  subLabel,
   type,
   id,
   disabled,
@@ -34,6 +36,7 @@ const FormInput = ({
       <Label className="entry-form-sub-title">
         {label} {required && <span className="entry-form-astrisk">*</span>}
       </Label>
+      {subLabel && <div className="entry-form-sub-title">{subLabel}</div>}
       {type === "select" ? (
         <Input
           type="select"


### PR DESCRIPTION
This pull request introduces a sublabel to the `FormInput` component in the `IsaacCompetition` entry form. The most important changes include adding the sublabel property to the `FormInput` component and updating the `CompetitionEntryForm` to use this new property.

Updates to `FormInput` component:

* [`src/app/components/pages/IsaacCompetition/EntryForm/FormInput.tsx`](diffhunk://#diff-5d8d44fb35ca0699a4c3c14813a65a11d7fb2f3e02e57c6a870c74364ebedceaR7): Added an optional `subLabel` property to the `FormInputProps` interface and updated the component to render the sublabel if provided. [[1]](diffhunk://#diff-5d8d44fb35ca0699a4c3c14813a65a11d7fb2f3e02e57c6a870c74364ebedceaR7) [[2]](diffhunk://#diff-5d8d44fb35ca0699a4c3c14813a65a11d7fb2f3e02e57c6a870c74364ebedceaR22) [[3]](diffhunk://#diff-5d8d44fb35ca0699a4c3c14813a65a11d7fb2f3e02e57c6a870c74364ebedceaR39)

Updates to `CompetitionEntryForm`:

* [`src/app/components/pages/IsaacCompetition/EntryForm/CompetitionEntryForm.tsx`](diffhunk://#diff-c49da7297210dcf67d9874abde48f3c73de63404b1417725b96b3b492f5efae4R102): Added a sublabel to the "Group" field to instruct users to ensure each group has no more than 4 students.