### PR TITLE
Competition Wrapper

### DIFF
--- a/src/app/components/pages/IsaacCompetition/CompetitionWrapper.tsx
+++ b/src/app/components/pages/IsaacCompetition/CompetitionWrapper.tsx
@@ -1,0 +1,19 @@
+import React from "react";
+
+const endDate = new Date("2025-03-28T16:00:00"); // 4 PM on Friday, March 28, 2025
+
+interface CompetitionWrapperProps {
+  children: React.ReactNode;
+}
+
+const CompetitionWrapper = ({ children }: CompetitionWrapperProps) => {
+  const currentDate = new Date();
+
+  if (currentDate > endDate) {
+    return null;
+  }
+
+  return <>{children}</>;
+};
+
+export default CompetitionWrapper;

--- a/src/app/components/pages/IsaacCompetition/CompetitionWrapper.tsx
+++ b/src/app/components/pages/IsaacCompetition/CompetitionWrapper.tsx
@@ -1,21 +1,19 @@
 import React from "react";
-
-const endDate = new Date("2025-03-28T16:00:00"); // 4 PM on Friday, March 28, 2025
-const fourWeeksAfterEndDate = new Date(endDate.getTime() + 4 * 7 * 24 * 60 * 60 * 1000); // 4 weeks after end date
+import { isWithinFourWeeksAfterEndDate, isAfterFourWeeksFromEndDate } from "../../pages/IsaacCompetition/dateUtils";
 
 interface CompetitionWrapperProps {
   children: React.ReactNode;
-  afterEndDateChildren?: React.ReactNode;
+  closedCompetitionContent?: React.ReactNode;
 }
 
-const CompetitionWrapper = ({ children, afterEndDateChildren }: CompetitionWrapperProps) => {
+const CompetitionWrapper = ({ children, closedCompetitionContent }: CompetitionWrapperProps) => {
   const currentDate = new Date();
 
-  if (currentDate > endDate && currentDate <= fourWeeksAfterEndDate) {
-    return <>{afterEndDateChildren}</>;
+  if (isWithinFourWeeksAfterEndDate(currentDate)) {
+    return <>{closedCompetitionContent}</>;
   }
 
-  if (currentDate > endDate) {
+  if (isAfterFourWeeksFromEndDate(currentDate)) {
     return null;
   }
 

--- a/src/app/components/pages/IsaacCompetition/CompetitionWrapper.tsx
+++ b/src/app/components/pages/IsaacCompetition/CompetitionWrapper.tsx
@@ -1,13 +1,19 @@
 import React from "react";
 
 const endDate = new Date("2025-03-28T16:00:00"); // 4 PM on Friday, March 28, 2025
+const fourWeeksAfterEndDate = new Date(endDate.getTime() + 4 * 7 * 24 * 60 * 60 * 1000); // 4 weeks after end date
 
 interface CompetitionWrapperProps {
   children: React.ReactNode;
+  afterEndDateChildren?: React.ReactNode;
 }
 
-const CompetitionWrapper = ({ children }: CompetitionWrapperProps) => {
+const CompetitionWrapper = ({ children, afterEndDateChildren }: CompetitionWrapperProps) => {
   const currentDate = new Date();
+
+  if (currentDate > endDate && currentDate <= fourWeeksAfterEndDate) {
+    return <>{afterEndDateChildren}</>;
+  }
 
   if (currentDate > endDate) {
     return null;

--- a/src/app/components/pages/IsaacCompetition/EntryForm/EntryFormHandler.tsx
+++ b/src/app/components/pages/IsaacCompetition/EntryForm/EntryFormHandler.tsx
@@ -55,7 +55,7 @@ const EntryFormHandler = ({ buttons, handleTermsClick }: EntryFormHandlerProps) 
 
   return (
     <CompetitionWrapper
-      afterEndDateChildren={
+      closedCompetitionContent={
         <Container>
           <Col className="d-flex flex-column align-items-start pb-4 pl-0" xs="auto">
             <p className="pb-3 body-text">{CLOSED_MESSAGE}</p>

--- a/src/app/components/pages/IsaacCompetition/EntryForm/EntryFormHandler.tsx
+++ b/src/app/components/pages/IsaacCompetition/EntryForm/EntryFormHandler.tsx
@@ -4,9 +4,11 @@ import CompetitionEntryForm from "./CompetitionEntryForm";
 import CompetitionButton from "../Buttons/CompetitionButton";
 import { selectors, useAppSelector } from "../../../../state";
 import { isStudent, isTeacher } from "../../../../services";
+import CompetitionWrapper from "../CompetitionWrapper";
 
 const STUDENT_MESSAGE = "Students, ask your teacher about submitting an entry.";
 const TEACHER_MESSAGE = "Teachers, login to submit a student project.";
+const CLOSED_MESSAGE = "Entries for this competition have now closed.";
 
 const StudentMessage = () => (
   <Container>
@@ -39,7 +41,11 @@ const EntryFormHandler = ({ buttons, handleTermsClick }: EntryFormHandlerProps) 
 
   const renderEntryForm = () => {
     if (isTeacher(user)) {
-      return <CompetitionEntryForm handleTermsClick={handleTermsClick} />;
+      return (
+        <CompetitionWrapper>
+          <CompetitionEntryForm handleTermsClick={handleTermsClick} />
+        </CompetitionWrapper>
+      );
     } else if (isStudent(user)) {
       return <StudentMessage />;
     } else {
@@ -47,7 +53,19 @@ const EntryFormHandler = ({ buttons, handleTermsClick }: EntryFormHandlerProps) 
     }
   };
 
-  return renderEntryForm();
+  return (
+    <CompetitionWrapper
+      afterEndDateChildren={
+        <Container>
+          <Col className="d-flex flex-column align-items-start pb-4 pl-0" xs="auto">
+            <p className="pb-3 body-text">{CLOSED_MESSAGE}</p>
+          </Col>
+        </Container>
+      }
+    >
+      {renderEntryForm()}
+    </CompetitionWrapper>
+  );
 };
 
 export default EntryFormHandler;

--- a/src/app/components/pages/IsaacCompetition/HomepageHighlight/HomepageHighlight.tsx
+++ b/src/app/components/pages/IsaacCompetition/HomepageHighlight/HomepageHighlight.tsx
@@ -1,27 +1,30 @@
 import React from "react";
 import { Container, Row, Col } from "reactstrap";
 import CompetitionButton from "../Buttons/CompetitionButton";
+import CompetitionWrapper from "../CompetitionWrapper";
 
 const HomepageHighlight = () => {
   return (
-    <Container className="pt-2 pb-5">
-      <Row className="homepage-highlight rounded justify-content-center">
-        <Col xs={12} className="text-center">
-          <h1 className="homepage-highlight-sub-title py-4">2025 National Computer Science competition</h1>
-          <h1 className="homepage-highlight-title pb-4">Entries are now open</h1>
-        </Col>
-        <Col xs={12} className="pb-4 text-center d-flex justify-content-center">
-          <CompetitionButton
-            buttons={[
-              {
-                to: "/national-computer-science-competition",
-                label: "Enter the competition",
-              },
-            ]}
-          />
-        </Col>
-      </Row>
-    </Container>
+    <CompetitionWrapper>
+      <Container className="pt-2 pb-5">
+        <Row className="homepage-highlight rounded justify-content-center">
+          <Col xs={12} className="text-center">
+            <h1 className="homepage-highlight-sub-title py-4">2025 National Computer Science competition</h1>
+            <h1 className="homepage-highlight-title pb-4">Entries are now open</h1>
+          </Col>
+          <Col xs={12} className="pb-4 text-center d-flex justify-content-center">
+            <CompetitionButton
+              buttons={[
+                {
+                  to: "/national-computer-science-competition",
+                  label: "Enter the competition",
+                },
+              ]}
+            />
+          </Col>
+        </Row>
+      </Container>
+    </CompetitionWrapper>
   );
 };
 

--- a/src/app/components/pages/IsaacCompetition/Tests/CompetitionWrapper.test.tsx
+++ b/src/app/components/pages/IsaacCompetition/Tests/CompetitionWrapper.test.tsx
@@ -25,7 +25,7 @@ describe("CompetitionWrapper", () => {
   it("renders afterEndDateChildren within 4 weeks after the end date", () => {
     jest.setSystemTime(new Date("2025-04-15T12:00:00")); // Within 4 weeks after the end date
     const { getByText } = render(
-      <CompetitionWrapper afterEndDateChildren={<div>Entries for this competition have now closed</div>}>
+      <CompetitionWrapper closedCompetitionContent={<div>Entries for this competition have now closed</div>}>
         <div>Competition is open</div>
       </CompetitionWrapper>,
     );
@@ -35,7 +35,7 @@ describe("CompetitionWrapper", () => {
   it("renders nothing after 4 weeks from the end date", () => {
     jest.setSystemTime(new Date("2025-05-01T12:00:00")); // After 4 weeks from the end date
     const { queryByText } = render(
-      <CompetitionWrapper afterEndDateChildren={<div>Entries for this competition have now closed</div>}>
+      <CompetitionWrapper closedCompetitionContent={<div>Entries for this competition have now closed</div>}>
         <div>Competition is open</div>
       </CompetitionWrapper>,
     );

--- a/src/app/components/pages/IsaacCompetition/Tests/CompetitionWrapper.test.tsx
+++ b/src/app/components/pages/IsaacCompetition/Tests/CompetitionWrapper.test.tsx
@@ -1,0 +1,45 @@
+import React from "react";
+import { render } from "@testing-library/react";
+import "@testing-library/jest-dom/extend-expect";
+import CompetitionWrapper from "../CompetitionWrapper";
+
+describe("CompetitionWrapper", () => {
+  beforeAll(() => {
+    jest.useFakeTimers();
+  });
+
+  afterAll(() => {
+    jest.useRealTimers();
+  });
+
+  it("renders children before the end date", () => {
+    jest.setSystemTime(new Date("2025-03-28T15:00:00")); // 1 hour before the end date
+    const { getByText } = render(
+      <CompetitionWrapper>
+        <div>Competition is open</div>
+      </CompetitionWrapper>,
+    );
+    expect(getByText("Competition is open")).toBeInTheDocument();
+  });
+
+  it("renders afterEndDateChildren within 4 weeks after the end date", () => {
+    jest.setSystemTime(new Date("2025-04-15T12:00:00")); // Within 4 weeks after the end date
+    const { getByText } = render(
+      <CompetitionWrapper afterEndDateChildren={<div>Entries for this competition have now closed</div>}>
+        <div>Competition is open</div>
+      </CompetitionWrapper>,
+    );
+    expect(getByText("Entries for this competition have now closed")).toBeInTheDocument();
+  });
+
+  it("renders nothing after 4 weeks from the end date", () => {
+    jest.setSystemTime(new Date("2025-05-01T12:00:00")); // After 4 weeks from the end date
+    const { queryByText } = render(
+      <CompetitionWrapper afterEndDateChildren={<div>Entries for this competition have now closed</div>}>
+        <div>Competition is open</div>
+      </CompetitionWrapper>,
+    );
+    expect(queryByText("Competition is open")).not.toBeInTheDocument();
+    expect(queryByText("Entries for this competition have now closed")).not.toBeInTheDocument();
+  });
+});

--- a/src/app/components/pages/IsaacCompetition/dateUtils.ts
+++ b/src/app/components/pages/IsaacCompetition/dateUtils.ts
@@ -1,0 +1,7 @@
+export const END_DATE = new Date("2025-03-28T16:00:00"); // 4 PM on Friday, March 28, 2025
+export const FOUR_WEEKS_AFTER_END_DATE = new Date(END_DATE.getTime() + 4 * 7 * 24 * 60 * 60 * 1000); // 4 weeks after end date
+
+export const isBeforeEndDate = (currentDate: Date) => currentDate <= END_DATE;
+export const isWithinFourWeeksAfterEndDate = (currentDate: Date) =>
+  currentDate > END_DATE && currentDate <= FOUR_WEEKS_AFTER_END_DATE;
+export const isAfterFourWeeksFromEndDate = (currentDate: Date) => currentDate > FOUR_WEEKS_AFTER_END_DATE;


### PR DESCRIPTION
This pull request introduces a new `CompetitionWrapper` component to manage the display of competition-related content based on specific date conditions. The component is integrated into various parts of the competition pages to handle the display of content before and after the competition end date.

Key changes include:

### New Component:

* [`src/app/components/pages/IsaacCompetition/CompetitionWrapper.tsx`](diffhunk://#diff-0531ea82021cac74e809bfbfd635458105f110f256077540eee344d69ee0ac73R1-R25): Created a `CompetitionWrapper` component that conditionally renders children based on the current date relative to the competition end date and a period of four weeks after the end date.

### Component Integration:

* [`src/app/components/pages/IsaacCompetition/EntryForm/EntryFormHandler.tsx`](diffhunk://#diff-d761348580dc61f898f9a4a9f655705918bb78b637816f4abd4627770946e7b2R7-R11): Integrated `CompetitionWrapper` to conditionally display the competition entry form and a message indicating that entries are closed after the competition end date. [[1]](diffhunk://#diff-d761348580dc61f898f9a4a9f655705918bb78b637816f4abd4627770946e7b2R7-R11) [[2]](diffhunk://#diff-d761348580dc61f898f9a4a9f655705918bb78b637816f4abd4627770946e7b2L42-R68)
* [`src/app/components/pages/IsaacCompetition/HomepageHighlight/HomepageHighlight.tsx`](diffhunk://#diff-c5908ca77d40b31f738119679f65b6198c99706d32c6aaae7591285647b799ceR4-R8): Wrapped the homepage highlight content in the `CompetitionWrapper` to manage its display based on the competition end date. [[1]](diffhunk://#diff-c5908ca77d40b31f738119679f65b6198c99706d32c6aaae7591285647b799ceR4-R8) [[2]](diffhunk://#diff-c5908ca77d40b31f738119679f65b6198c99706d32c6aaae7591285647b799ceR27)