### PR TITLE
637/shav-competition-extension

### DIFF
--- a/src/app/components/pages/IsaacCompetition/EntryForm/CompetitionEntryForm.tsx
+++ b/src/app/components/pages/IsaacCompetition/EntryForm/CompetitionEntryForm.tsx
@@ -89,7 +89,7 @@ const CompetitionEntryForm = ({ handleTermsClick }: CompetitionEntryFormProps) =
               </Col>
               <Col lg={6}>
                 <FormInput
-                  label="Link to submission"
+                  label="Link to a students' project"
                   type="text"
                   id="submissionLink"
                   required

--- a/src/app/components/pages/IsaacCompetition/Tests/CompetitionWrapper.test.tsx
+++ b/src/app/components/pages/IsaacCompetition/Tests/CompetitionWrapper.test.tsx
@@ -13,7 +13,7 @@ describe("CompetitionWrapper", () => {
   });
 
   it("renders children before the end date", () => {
-    jest.setSystemTime(new Date("2025-03-28T15:00:00")); // 1 hour before the end date
+    jest.setSystemTime(new Date("2025-04-07T15:00:00")); // 1 hour before the end date
     const { getByText } = render(
       <CompetitionWrapper>
         <div>Competition is open</div>
@@ -23,7 +23,7 @@ describe("CompetitionWrapper", () => {
   });
 
   it("renders afterEndDateChildren within 4 weeks after the end date", () => {
-    jest.setSystemTime(new Date("2025-04-15T12:00:00")); // Within 4 weeks after the end date
+    jest.setSystemTime(new Date("2025-05-05T12:00:00")); // Within 4 weeks after the end date
     const { getByText } = render(
       <CompetitionWrapper closedCompetitionContent={<div>Entries for this competition have now closed</div>}>
         <div>Competition is open</div>
@@ -33,7 +33,7 @@ describe("CompetitionWrapper", () => {
   });
 
   it("renders nothing after 4 weeks from the end date", () => {
-    jest.setSystemTime(new Date("2025-05-01T12:00:00")); // After 4 weeks from the end date
+    jest.setSystemTime(new Date("2025-06-02T12:00:00")); // After 4 weeks from the end date
     const { queryByText } = render(
       <CompetitionWrapper closedCompetitionContent={<div>Entries for this competition have now closed</div>}>
         <div>Competition is open</div>

--- a/src/app/components/pages/IsaacCompetition/content.ts
+++ b/src/app/components/pages/IsaacCompetition/content.ts
@@ -7,9 +7,9 @@ export default {
       ],
     },
     note: {
-      heading: "Please note:",
+      heading: "Teachers - good news!",
       entryDetails:
-        "Competition entries open in January and last two months. Students will be able to submit their entries until 28 March 16:00. Follow our",
+        "The deadline has been extended. Make sure to submit your students' project by 7 April at 16:00. Follow our",
       callToAction: "accounts for updates.",
       xLink: "https://x.com/isaaccompsci",
       facebookLink: "https://www.facebook.com/IsaacComputerScience",
@@ -43,9 +43,9 @@ export default {
       steps: [
         "1. Students need to ask their teacher to participate",
         "2. Students and teachers create or log in to an account",
-        "3. Attend our Q&A sessions for tips and tricks on entries (coming soon)",
-        "4. Boost your knowledge with our Student Boosters and Gameboards",
-        "5. Submit your entry! The finalists will be selected and invited to a final in Birmingham on 19 May.",
+        "3. Boost your knowledge with our Student Boosters and Gameboards",
+        "4. Work individually or in a group to develop a project, record a video, and ask your teacher to submit it",
+        "5. Teachers submit students' projects. The finalists will be selected and invited to a final in Birmingham on 19 May 2025.",
       ],
     },
     whyJoin: {
@@ -80,7 +80,7 @@ export default {
         "Save the 2024/25 dates in your calendar and plan time for you or your team to develop your IoE idea before applications close.",
       entries: [
         { event: "Entries open", date: "January" },
-        { event: "Entries close", date: "28 March 16:00" },
+        { event: "Entries close", date: "7th April 16:00" },
         { event: "Finalist selected", date: "April" },
         { event: "The final", date: "19 May" },
       ],
@@ -195,17 +195,17 @@ export default {
     industry: {
       title: "Industry Partners",
       section: [
-        "A big thank you to all of our industry partners! These include:",
+        "A big thank you to our industry partners for their support and generous prizes! Sincere appreciation for the contributions from:",
         [
           "The British Computer Society, branded BCS, The Chartered Institute for IT",
           "Cisco",
           "Kainos",
           "Reed",
           "Siemens",
-          "TC",
+          "Dassault Systèmes",
         ],
         "",
-        "A big thank you to Birmingham City University for giving us space to host the finals. The University has offered continuous support throughout the competition, and we are excited to partner with them and be a part of the Innovation Fest 19th May - 23rd May 2025.",
+        "A special thank you to Birmingham City University for providing the space to host the competition final. Their continued support throughout the competition has been invaluable, and it's exciting to partner with them and be a part of Innovation Fest, taking place 19 - 23 May 2025.",
       ],
     },
     termsAndConditions: {

--- a/src/app/components/pages/IsaacCompetition/dateUtils.ts
+++ b/src/app/components/pages/IsaacCompetition/dateUtils.ts
@@ -1,4 +1,4 @@
-export const END_DATE = new Date("2025-03-28T16:00:00"); // 4 PM on Friday, March 28, 2025
+export const END_DATE = new Date("2025-04-07T16:00:00"); // Monday 7th April 2025 at 4pm
 export const FOUR_WEEKS_AFTER_END_DATE = new Date(END_DATE.getTime() + 4 * 7 * 24 * 60 * 60 * 1000); // 4 weeks after end date
 
 export const isBeforeEndDate = (currentDate: Date) => currentDate <= END_DATE;


### PR DESCRIPTION
Description:
This pull request implements several updates to extend the competition deadline and refresh associated content. The competition deadline has been extended to `April 7th, 2025, at 16:00`, with the submission form reopening on Monday morning. Text updates include a new deadline announcement, a field title change to `"Link to a students' project,"` and revised steps in the `"How does it work?"` section. The competition timeline now reflects the updated deadline, and the industry partners section has been revised to acknowledge their contributions and Birmingham City University's support. All changes have been verified for accuracy and consistency across the platform.

Ticket: https://github.com/isaaccomputerscience/isaac-cs-issues/issues/637

Media Attachement(s):
<img width="1711" alt="Screenshot 2025-03-31 at 13 46 55" src="https://github.com/user-attachments/assets/9e2a585b-0ad7-42f0-b435-b1456e4f3b00" />
<img width="1186" alt="Screenshot 2025-03-31 at 13 46 40" src="https://github.com/user-attachments/assets/16365622-dee3-4eb5-9192-6e5ac63166b4" />
<img width="1224" alt="Screenshot 2025-03-31 at 13 46 33" src="https://github.com/user-attachments/assets/c30f85f7-aaac-47a1-9871-fa12c5a28b2e" />
<img width="1522" alt="Screenshot 2025-03-31 at 13 46 26" src="https://github.com/user-attachments/assets/0abaf188-64ef-4e42-94e0-6d2c6beca3bf" />
