### PR TITLE
Sign up consent

### DIFF
--- a/src/app/components/elements/consent/Consent.tsx
+++ b/src/app/components/elements/consent/Consent.tsx
@@ -40,7 +40,7 @@ const Consent = ({ consentText, required = true, onConsentChange }: ConsentProps
     return (
       <>
         {text.beforeLink}
-        <Link to={text.linkTo ?? "/privacy"} target="_blank">
+        <Link to={text.linkTo ? text.linkTo : "/privacy"} target="_blank">
           {text.linkText}
         </Link>
         {text.afterLink}

--- a/src/app/components/elements/consent/Consent.tsx
+++ b/src/app/components/elements/consent/Consent.tsx
@@ -54,7 +54,7 @@ const Consent = ({ consentText, required = true, onConsentChange }: ConsentProps
         <input
           id={inputId}
           name="consent"
-          aria-label="Consent checkbox for event registration"
+          aria-label="Consent checkbox"
           className="large-checkbox"
           type="checkbox"
           checked={isChecked}

--- a/src/app/components/elements/consent/Consent.tsx
+++ b/src/app/components/elements/consent/Consent.tsx
@@ -40,7 +40,7 @@ const Consent = ({ consentText, required = true, onConsentChange }: ConsentProps
     return (
       <>
         {text.beforeLink}
-        <Link to={text.linkTo || "/privacy"} target="_blank">
+        <Link to={text.linkTo ?? "/privacy"} target="_blank">
           {text.linkText}
         </Link>
         {text.afterLink}

--- a/src/app/components/elements/consent/Consent.tsx
+++ b/src/app/components/elements/consent/Consent.tsx
@@ -1,14 +1,18 @@
+/*
+ * This component has been made to give consent on event registration and account sign up.
+ * All new consent given will be added in the database as given consent.
+ * All past consent will be displayed as false, however it is applied consent.
+ */
 import React, { useState } from "react";
 import { Col, Row } from "reactstrap";
 import { Link } from "react-router-dom";
 
-//Props for the Consent component
-// This component is used to display a consent checkbox with customisable text
-//The text contains beforeLink, linkText, and afterLink properties
 interface ConsentText {
   beforeLink: string;
   linkText: string;
+  linkTo?: string;
   afterLink: string;
+  sameLine?: boolean;
 }
 
 interface ConsentProps {
@@ -17,7 +21,7 @@ interface ConsentProps {
   onConsentChange?: (checked: boolean) => void;
 }
 
-const EventConsent = ({ consentText, required = true, onConsentChange }: ConsentProps) => {
+const Consent = ({ consentText, required = true, onConsentChange }: ConsentProps) => {
   const [isChecked, setIsChecked] = useState(false);
   const inputId = "consent-checkbox";
 
@@ -36,7 +40,7 @@ const EventConsent = ({ consentText, required = true, onConsentChange }: Consent
     return (
       <>
         {text.beforeLink}
-        <Link to="/privacy" target="_blank">
+        <Link to={text.linkTo || "/privacy"} target="_blank">
           {text.linkText}
         </Link>
         {text.afterLink}
@@ -62,16 +66,22 @@ const EventConsent = ({ consentText, required = true, onConsentChange }: Consent
       </Col>
       <Col>
         <label htmlFor={inputId}>
-          {consentText.map((text, index) => (
-            <React.Fragment key={`consent-${typeof text === "string" ? "text" : "link"}-${index}`}>
-              {renderConsentText(text)}
-              {index < consentText.length - 1 && <div className="mt-2" />}
-            </React.Fragment>
-          ))}
+          {consentText.map((text, index) => {
+            const nextItem = consentText[index + 1];
+            const shouldAddBreak =
+              typeof nextItem === "object" && !nextItem?.sameLine && index < consentText.length - 1;
+
+            return (
+              <React.Fragment key={`consent-${typeof text === "string" ? "text" : "link"}-${index}`}>
+                {renderConsentText(text)}
+                {shouldAddBreak && <div className="mt-2" />}
+              </React.Fragment>
+            );
+          })}
         </label>
       </Col>
     </Row>
   );
 };
 
-export default EventConsent;
+export default Consent;

--- a/src/app/components/elements/consent/consentData.ts
+++ b/src/app/components/elements/consent/consentData.ts
@@ -17,5 +17,21 @@ export const consentData = {
         afterLink: ".",
       },
     ],
+    SignUpConsent: [
+      {
+        beforeLink:
+          "By ticking this box, you are confirming that you have read and agree to the Isaac Computer Science ",
+        linkText: "Terms of Use",
+        linkTo: "/terms",
+        afterLink: " and ",
+      },
+      {
+        beforeLink: "",
+        linkText: "Privacy Policy",
+        linkTo: "/privacy",
+        afterLink: ".",
+        sameLine: true, // Add this property to keep it on the same line
+      },
+    ],
   },
 };

--- a/src/app/components/elements/inputs/RegistrationSubmit.tsx
+++ b/src/app/components/elements/inputs/RegistrationSubmit.tsx
@@ -29,6 +29,7 @@ export const RegistrationSubmit: React.FC<RegistrationSubmitProps> = ({ isRecapt
           <Input
             type="submit"
             value="Register my account"
+            //Button is disabled if recaptcha is not ticked and consent is not given
             disabled={!isRecaptchaTicked || !isConsented}
             className="btn btn-block btn-secondary border-0"
           />

--- a/src/app/components/elements/inputs/RegistrationSubmit.tsx
+++ b/src/app/components/elements/inputs/RegistrationSubmit.tsx
@@ -1,25 +1,26 @@
-import React from "react";
-import { Link } from "react-router-dom";
+import React, { useState } from "react";
 import { Col, Input, Row } from "reactstrap";
+import Consent from "../consent/Consent";
+import { consentData } from "../consent/consentData";
 
 interface RegistrationSubmitProps {
   isRecaptchaTicked: boolean;
 }
 
+const { SignUpConsent } = consentData.consent;
+
 export const RegistrationSubmit: React.FC<RegistrationSubmitProps> = ({ isRecaptchaTicked }) => {
+  const [isConsented, setIsConsented] = useState(false);
+
+  const handleConsentChange = (checked: boolean) => {
+    setIsConsented(checked);
+  };
+
   return (
     <>
-      <Row>
-        <Col className="text-center text-muted mt-3">
-          {"By clicking 'Register my account', you accept our "}
-          <Link to="/terms" target="_blank">
-            Terms of Use
-          </Link>
-          . Find out about our{" "}
-          <Link to="/privacy" target="_blank">
-            Privacy Policy
-          </Link>
-          .
+      <Row className="justify-content-center">
+        <Col md={9} className="text-start mt-3">
+          <Consent consentText={SignUpConsent} required={true} onConsentChange={handleConsentChange} />
         </Col>
       </Row>
 
@@ -28,7 +29,7 @@ export const RegistrationSubmit: React.FC<RegistrationSubmitProps> = ({ isRecapt
           <Input
             type="submit"
             value="Register my account"
-            disabled={!isRecaptchaTicked}
+            disabled={!isRecaptchaTicked || !isConsented}
             className="btn btn-block btn-secondary border-0"
           />
         </Col>

--- a/src/app/components/pages/EventDetails.tsx
+++ b/src/app/components/pages/EventDetails.tsx
@@ -54,7 +54,7 @@ import * as L from "leaflet";
 import ReactGA from "react-ga4";
 import { UserSummaryWithEmailAddressAndGenderDTO } from "../../../IsaacApiTypes";
 import { Immutable } from "immer";
-import EventConsent from "../elements/consent/EventConsent";
+import Consent from "../elements/consent/Consent";
 import { consentData } from "../elements/consent/consentData";
 
 interface EventDetailsProps {
@@ -350,13 +350,13 @@ const EventDetails = ({
 
                               <div className="mb-3">
                                 {isVirtual ? (
-                                  <EventConsent
+                                  <Consent
                                     consentText={VirtualEventConsent}
                                     required={true}
                                     onConsentChange={handleConsentChange}
                                   />
                                 ) : (
-                                  <EventConsent
+                                  <Consent
                                     consentText={InPersonEventConsent}
                                     required={true}
                                     onConsentChange={handleConsentChange}

--- a/src/test/components/elements/inputs/RegistrationSubmit.test.tsx
+++ b/src/test/components/elements/inputs/RegistrationSubmit.test.tsx
@@ -1,6 +1,7 @@
 import { screen } from "@testing-library/react";
 import { RegistrationSubmit } from "../../../../app/components/elements/inputs/RegistrationSubmit";
 import { getFormFields, renderTestEnvironment } from "../../../utils";
+import userEvent from "@testing-library/user-event";
 
 describe("RegistrationSubmit", () => {
   const setupTest = (props = {}) => {
@@ -17,13 +18,15 @@ describe("RegistrationSubmit", () => {
 
   it("renders the component", () => {
     setupTest();
-    expect(screen.getByText(/by clicking 'register my account'/i)).toBeInTheDocument();
+    expect(screen.getByText(/by ticking this box/i)).toBeInTheDocument();
     const { submitButton } = getFormFields();
     expect(submitButton()).toBeInTheDocument();
   });
 
-  it("submit button is enabled when isRecaptchaTicked is true", () => {
+  it("submit button is enabled when isRecaptchaTicked is true", async () => {
     setupTest();
+    const consentCheckbox = screen.getByRole("checkbox", { name: "Consent checkbox" });
+    await userEvent.click(consentCheckbox);
     const { submitButton } = getFormFields();
     expect(submitButton()).toBeEnabled();
   });

--- a/src/test/pages/EventDetails.test.tsx
+++ b/src/test/pages/EventDetails.test.tsx
@@ -73,7 +73,7 @@ describe("EventDetails", () => {
     [firstNameInput, familyNameInput, stageInput, examBoardInput].forEach((each) => expect(each).toBeValid());
 
     return {
-      consentCheckbox: screen.getByRole("checkbox", { name: "Consent checkbox for event registration" }),
+      consentCheckbox: screen.getByRole("checkbox", { name: "Consent checkbox" }),
       bookNowButton: screen.getByRole("button", { name: "Book now" }),
     };
   };

--- a/src/test/pages/StudentRegistration.test.tsx
+++ b/src/test/pages/StudentRegistration.test.tsx
@@ -8,6 +8,7 @@ import { API_PATH } from "../../app/services";
 import { registrationMockUser, registrationUserData } from "../../mocks/data";
 
 const registerUserSpy = jest.spyOn(actions, "registerUser");
+const consentCheckbox = screen.getByRole("checkbox", { name: "Consent checkbox" });
 
 const checkPasswordInputTypes = (expectedType: string) => {
   const formFields = getFormFields();
@@ -132,6 +133,7 @@ describe("Student Registration", () => {
     const formFields = getFormFields();
     const { submitButton, recaptcha } = formFields;
     expect(submitButton()).toBeDisabled();
+    await userEvent.click(consentCheckbox);
     await userEvent.click(recaptcha());
     expect(submitButton()).toBeEnabled();
   });

--- a/src/test/pages/StudentRegistration.test.tsx
+++ b/src/test/pages/StudentRegistration.test.tsx
@@ -8,7 +8,6 @@ import { API_PATH } from "../../app/services";
 import { registrationMockUser, registrationUserData } from "../../mocks/data";
 
 const registerUserSpy = jest.spyOn(actions, "registerUser");
-const consentCheckbox = screen.getByRole("checkbox", { name: "Consent checkbox" });
 
 const checkPasswordInputTypes = (expectedType: string) => {
   const formFields = getFormFields();
@@ -80,6 +79,8 @@ describe("Student Registration", () => {
   it("displays error messages if fields are filled in wrong", async () => {
     renderStudentRegistration();
     await fillFormCorrectly(false, "student");
+    const consentCheckbox = screen.getByRole("checkbox", { name: "Consent checkbox" });
+    await userEvent.click(consentCheckbox);
     await clickButton("Register my account");
     const pwErrorMessage = screen.getByText(/Passwords must be at least 12 characters/i);
     expect(pwErrorMessage).toBeVisible();
@@ -92,6 +93,8 @@ describe("Student Registration", () => {
   it("attempts to create a user when submit is pressed, if fields are filled in correctly", async () => {
     renderStudentRegistration();
     await fillFormCorrectly(true, "student");
+    const consentCheckbox = screen.getByRole("checkbox", { name: "Consent checkbox" });
+    await userEvent.click(consentCheckbox);
     await clickButton("Register my account");
 
     expect(registerUserSpy).toHaveBeenCalledWith(
@@ -122,6 +125,8 @@ describe("Student Registration", () => {
   it("redirects to registration success page after form submission", async () => {
     renderStudentRegistration();
     await fillFormCorrectly(true, "student");
+    const consentCheckbox = screen.getByRole("checkbox", { name: "Consent checkbox" });
+    await userEvent.click(consentCheckbox);
     await clickButton("Register my account");
     const newPage = location.pathname;
     expect(newPage).toBe("/register/success");
@@ -133,6 +138,7 @@ describe("Student Registration", () => {
     const formFields = getFormFields();
     const { submitButton, recaptcha } = formFields;
     expect(submitButton()).toBeDisabled();
+    const consentCheckbox = screen.getByRole("checkbox", { name: "Consent checkbox" });
     await userEvent.click(consentCheckbox);
     await userEvent.click(recaptcha());
     expect(submitButton()).toBeEnabled();

--- a/src/test/pages/TeacherRegistration.test.tsx
+++ b/src/test/pages/TeacherRegistration.test.tsx
@@ -18,6 +18,7 @@ import { registrationMockUser, registrationUserData } from "../../mocks/data";
 
 const registerUserSpy = jest.spyOn(actions, "registerUser");
 const upgradeAccountSpy = jest.spyOn(actions, "upgradeAccount");
+const consentCheckbox = screen.getByRole("checkbox", { name: "Consent checkbox" });
 
 const confirmTeacherAndAcceptTerms = async () => {
   await clickButton("Yes, I am a teacher");
@@ -154,6 +155,7 @@ describe("Teacher Registration", () => {
     renderTeacherRegistration();
     await confirmTeacherAndAcceptTerms();
     await fillFormCorrectly(true, "teacher");
+    await userEvent.click(consentCheckbox);
     await clickButton("Register my account");
     expect(registerUserSpy).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -191,6 +193,7 @@ describe("Teacher Registration", () => {
     renderTeacherRegistration();
     await confirmTeacherAndAcceptTerms();
     await fillFormCorrectly(true, "teacher");
+    await userEvent.click(consentCheckbox);
     await clickButton("Register my account");
     const newPage = location.pathname;
     expect(newPage).toBe("/register/success");

--- a/src/test/pages/TeacherRegistration.test.tsx
+++ b/src/test/pages/TeacherRegistration.test.tsx
@@ -18,7 +18,6 @@ import { registrationMockUser, registrationUserData } from "../../mocks/data";
 
 const registerUserSpy = jest.spyOn(actions, "registerUser");
 const upgradeAccountSpy = jest.spyOn(actions, "upgradeAccount");
-const consentCheckbox = screen.getByRole("checkbox", { name: "Consent checkbox" });
 
 const confirmTeacherAndAcceptTerms = async () => {
   await clickButton("Yes, I am a teacher");
@@ -133,6 +132,8 @@ describe("Teacher Registration", () => {
     expect(newPwErrorMessage).toBeVisible();
     // update PW to meet requirements and try to submit, observe error messages for school, stage and email address
     await fillTextField(password(), registrationUserData.password);
+    const consentCheckbox = screen.getByRole("checkbox", { name: "Consent checkbox" });
+    await userEvent.click(consentCheckbox);
     await clickButton("Register my account");
     const schoolErrorMessage = screen.getByText(/Please specify a school or college/i);
     const stageErrorMessage = getById("user-context-feedback");
@@ -155,6 +156,7 @@ describe("Teacher Registration", () => {
     renderTeacherRegistration();
     await confirmTeacherAndAcceptTerms();
     await fillFormCorrectly(true, "teacher");
+    const consentCheckbox = screen.getByRole("checkbox", { name: "Consent checkbox" });
     await userEvent.click(consentCheckbox);
     await clickButton("Register my account");
     expect(registerUserSpy).toHaveBeenCalledWith(
@@ -193,6 +195,7 @@ describe("Teacher Registration", () => {
     renderTeacherRegistration();
     await confirmTeacherAndAcceptTerms();
     await fillFormCorrectly(true, "teacher");
+    const consentCheckbox = screen.getByRole("checkbox", { name: "Consent checkbox" });
     await userEvent.click(consentCheckbox);
     await clickButton("Register my account");
     const newPage = location.pathname;


### PR DESCRIPTION
Ticket: https://github.com/isaaccomputerscience/isaac-cs-issues/issues/647

This pull request introduces a new, reusable Consent component for managing user consent, and integrates it into the account sign-up process. Here’s a summary of the main changes:

- Renames and generalises the existing EventConsent component to Consent, allowing it to be used for both event registration and account sign-up.
- Updates the consentData file to include new consent text specifically for sign-up, referencing the Terms of Use and Privacy Policy.
- Modifies the RegistrationSubmit component: users must now explicitly tick a consent checkbox before registering an account. The "Register my account" button is only enabled once both reCAPTCHA is ticked and consent is given.
- Updates the EventDetails component to use the new Consent component.
- Updates and adds tests to reflect the new consent requirements and UI changes, ensuring the consent checkbox is present and required for registration.
