### PR TITLE
GCSE Teaching Order

### DIFF
--- a/src/app/components/elements/GeneralPage.tsx
+++ b/src/app/components/elements/GeneralPage.tsx
@@ -1,0 +1,40 @@
+import React, { ReactElement } from "react";
+import { ShowLoading } from "../handlers/ShowLoading";
+import { IsaacContent } from "../content/IsaacContent";
+import { WithFigureNumbering } from "./WithFigureNumbering";
+import { EditContentButton } from "./EditContentButton";
+import { isaacApi, resultOrNotFound } from "../../state";
+
+interface PageContentProps {
+  pageId: string;
+  ifNotFound?: ReactElement;
+}
+
+export const PageContent = ({ pageId, ifNotFound }: PageContentProps) => {
+  const { data: page, error } = isaacApi.endpoints.getPage.useQuery(pageId);
+
+  const defaultNotFoundComponent = (
+    <div>
+      <h2>Content not found</h2>
+      <h3 className="my-4">
+        <small>
+          {"We're sorry, page not found: "}
+          <code>{pageId}</code>
+        </small>
+      </h3>
+    </div>
+  );
+
+  return (
+    <ShowLoading
+      until={resultOrNotFound(page, error)}
+      ifNotFound={ifNotFound || defaultNotFoundComponent}
+      thenRender={(page) => (
+        <WithFigureNumbering doc={page}>
+          <EditContentButton doc={page} />
+          <IsaacContent doc={page} />
+        </WithFigureNumbering>
+      )}
+    />
+  );
+};

--- a/src/app/components/pages/GCSETeachingOrder.tsx
+++ b/src/app/components/pages/GCSETeachingOrder.tsx
@@ -1,0 +1,62 @@
+import React, { useEffect } from "react";
+import { useHistory, useLocation } from "react-router-dom";
+import { Col, Container, Row } from "reactstrap";
+import { TitleAndBreadcrumb } from "../elements/TitleAndBreadcrumb";
+import { EXAM_BOARD, EXAM_BOARDS_CS_GCSE, STAGE } from "../../services";
+import { PageContent } from "../elements/GeneralPage";
+import { Tabs } from "../elements/Tabs";
+
+export const GCSETeachingOrder = () => {
+  const history = useHistory();
+  const location = useLocation();
+
+  const stage = STAGE.GCSE;
+  const stageExamBoards = Array.from(EXAM_BOARDS_CS_GCSE).filter((board) =>
+    ["aqa", "edexcel", "ocr"].includes(board.toLowerCase()),
+  );
+  // Tab logic for GCSE only
+  const activeTab = stageExamBoards.indexOf(location.hash.replace("#", "").toLowerCase() as EXAM_BOARD) + 1 || 1;
+  function setActiveTab(tabIndex: number) {
+    if (tabIndex < 1 || tabIndex > stageExamBoards.length) return;
+    const hash = stageExamBoards[tabIndex - 1].toString();
+    history.replace({ ...location, hash: `#${hash}` });
+  }
+  useEffect(() => {
+    if (!location.hash) setActiveTab(activeTab);
+  });
+
+  return (
+    <div className="pattern-02">
+      <Container>
+        <TitleAndBreadcrumb currentPageTitle="GCSE teaching order" />
+
+        <Tabs
+          className="pt-3"
+          tabContentClass="pt-3"
+          activeTabOverride={activeTab}
+          refreshHash={stage}
+          onActiveTabChange={setActiveTab}
+        >
+          {Object.assign(
+            {},
+            ...stageExamBoards.map((examBoard) => ({
+              [examBoard.toUpperCase()]: (
+                <Row>
+                  <Col lg={{ size: 8, offset: 2 }} className="bg-light-grey py-md-4">
+                    <PageContent
+                      pageId={
+                        examBoard.toLowerCase() === "edexcel"
+                          ? "40975805-b61a-4d54-bb62-95156e1f5509"
+                          : `teaching_order_g_${examBoard}`
+                      }
+                    />
+                  </Col>
+                </Row>
+              ),
+            })),
+          )}
+        </Tabs>
+      </Container>
+    </div>
+  );
+};

--- a/src/app/components/site/NavigationBar.tsx
+++ b/src/app/components/site/NavigationBar.tsx
@@ -40,8 +40,7 @@ export const NavigationBar = () => {
           {isTeacherOrAbove(user) && (
             <>
               <LinkItem to="/set_tests">Manage tests</LinkItem>
-              <LinkItem to="/teaching_order_g_ocr">GCSE suggested teaching order (OCR)</LinkItem>
-              <LinkItem to="/teaching_order_g_aqa">GCSE suggested teaching order (AQA)</LinkItem>
+              <LinkItem to="/gcse_teaching_order">GCSE suggested teaching order</LinkItem>
               <LinkItem to="/teaching_order">A Level suggested teaching order</LinkItem>
             </>
           )}

--- a/src/app/components/site/Routes.tsx
+++ b/src/app/components/site/Routes.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { TrackedRoute } from "../navigation/TrackedRoute";
 import { AllTopics, AllTopicsWithoutAStage } from "../pages/AllTopics";
+import { GCSETeachingOrder } from "../pages/GCSETeachingOrder";
 import StaticPageRoute from "../navigation/StaticPageRoute";
 import { ComingSoon } from "../pages/ComingSoon";
 import { Topic } from "../pages/Topic";
@@ -77,20 +78,16 @@ export const Routes = [
   // Static pages:
   <StaticPageRoute key={key++} exact path="/about" pageId="about_us" />,
   <StaticPageRoute key={key++} exact path="/safeguarding" pageId="events_safeguarding" />,
-  <StaticPageRoute
+  <TrackedRoute
     key={key++}
     exact
     ifUser={isTutorOrAbove}
-    path="/teaching_order_g_ocr"
-    pageId="teaching_order_g_ocr"
+    path="/gcse_teaching_order"
+    component={GCSETeachingOrder}
+    componentProps={{ stage: STAGE.GCSE }}
+    userAgent={window.navigator.userAgent}
   />,
-  <StaticPageRoute
-    key={key++}
-    exact
-    ifUser={isTutorOrAbove}
-    path="/teaching_order_g_aqa"
-    pageId="teaching_order_g_aqa"
-  />,
+
   <StaticPageRoute key={key++} exact ifUser={isTutorOrAbove} path="/teaching_order" pageId="teaching_order" />,
   <StaticPageRoute key={key++} exact path="/teachcomputing" pageId="teach_computing" />,
   <StaticPageRoute key={key++} exact path="/gcse_programming_challenges" pageId="gcse_programming_challenges" />,

--- a/src/app/state/slices/api/index.ts
+++ b/src/app/state/slices/api/index.ts
@@ -226,6 +226,13 @@ const isaacApi = createApi({
       keepUnusedDataFor: 60,
     }),
 
+    getPage: build.query<IsaacConceptPageDTO, string>({
+      query: (pageID) => ({
+        url: `/pages/${pageID}`,
+      }),
+      keepUnusedDataFor: 60,
+    }),
+
     // === Gameboards ===
 
     getGameboards: build.query<Boards, { startIndex: number; limit: NumberOfBoards; sort: BoardOrder }>({


### PR DESCRIPTION
Ticket Link: https://github.com/isaaccomputerscience/isaac-cs-issues/issues/527

This pull request introduces a new "GCSE suggested teaching order" page for teachers in the Isaac Computer Science app. Here’s a summary of the changes:

- Adds a new page component (GCSETeachingOrder) that displays suggested teaching orders for different GCSE exam boards (AQA, Edexcel, OCR) using tabs.
- Introduces a reusable PageContent component to fetch and render content by page ID.
- Updates the navigation bar so there's a single link for "GCSE suggested teaching order" instead of separate links for AQA and OCR.
- Updates route definitions to point to the new GCSE teaching order page ("/gcse_teaching_order") for teachers, replacing the previous individual exam board pages.
- Adds a new API endpoint to fetch page content by page ID.

Overall, this PR streamlines access to GCSE teaching order content, consolidates related pages into a tabbed interface, and improves maintainability.