### PR TITLE
Updated ribbon logic to remove N/A and add GCSE/A level

### DIFF
--- a/src/app/components/elements/cards/EventCard.tsx
+++ b/src/app/components/elements/cards/EventCard.tsx
@@ -26,15 +26,20 @@ export const EventCard = ({ event, pod = false }: { event: AugmentedEvent; pod?:
   } = event;
 
   const getCourseName = (subtitle: string | undefined) => {
-    if (!subtitle) return "N/A";
+    if (!subtitle) return "GCSE/A level";
 
     const lowerCaseSubtitle = subtitle.toLowerCase();
-    if (lowerCaseSubtitle.includes("gcse")) {
+    const hasGcse = lowerCaseSubtitle.includes("gcse");
+    const hasALevel = lowerCaseSubtitle.includes("a level");
+
+    if (hasGcse && hasALevel) {
+      return "GCSE/A level";
+    } else if (hasGcse) {
       return "GCSE";
-    } else if (lowerCaseSubtitle.includes("a level")) {
+    } else if (hasALevel) {
       return "A level";
     } else {
-      return "N/A";
+      return "GCSE/A level";
     }
   };
 


### PR DESCRIPTION
This pull request updates the EventCard component to improve how it displays the course name based on the event's subtitle. Specifically:

- If the subtitle contains both "GCSE" and "A level", it now shows "GCSE/A level".
- If only "GCSE" is present, it shows "GCSE".
- If only "A level" is present, it shows "A level".
- If neither is found or the subtitle is missing, it defaults to "GCSE/A level" instead of "N/A".
